### PR TITLE
Fix Compilation, due to the Theme Enum not getting recognized

### DIFF
--- a/src/statusbar_android.cpp
+++ b/src/statusbar_android.cpp
@@ -63,7 +63,7 @@ void StatusBarPrivate::setTheme_sys(StatusBar::Theme theme)
         QAndroidJniObject window = getAndroidWindow();
         QAndroidJniObject view = window.callObjectMethod("getDecorView", "()Landroid/view/View;");
         int visibility = view.callMethod<int>("getSystemUiVisibility", "()I");
-        if (theme == Light)
+        if (theme == StatusBar::Theme::Light)
             visibility |= SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
         else
             visibility &= ~SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;


### PR DESCRIPTION
After cloning I needed to change this to use the complete Enum, because otherwise it wouldn't compile due to Light not being defined.