### PR TITLE
fix: restore preferred StatsBarStyle onOrientationChanged

### DIFF
--- a/src/statusbar_ios.mm
+++ b/src/statusbar_ios.mm
@@ -68,17 +68,12 @@ void togglePreferredStatusBarStyle()
     UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
     if (keyWindow)
         setPreferredStatusBarStyle(keyWindow, style);
-
-    QTimer* timer = new QTimer();
-    timer->setInterval(200);
-    timer->setSingleShot(true);
-    QObject::connect(timer, &QTimer::timeout, timer, []() {
+    QTimer::singleShot(200, []() {
         UIStatusBarStyle style = statusBarStyle(StatusBarPrivate::theme);
         UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
         if (keyWindow)
             setPreferredStatusBarStyle(keyWindow, style);
-    }, Qt::UniqueConnection);
-    timer->start();
+    });
 }
 
 static void updatePreferredStatusBarStyle()

--- a/src/statusbar_ios.mm
+++ b/src/statusbar_ios.mm
@@ -25,6 +25,9 @@
 #include <UIKit/UIKit.h>
 #include <QGuiApplication>
 
+#include <QScreen>
+#include <QTimer>
+
 @interface QIOSViewController : UIViewController
 @property (nonatomic, assign) BOOL prefersStatusBarHidden;
 @property (nonatomic, assign) UIStatusBarAnimation preferredStatusBarUpdateAnimation;
@@ -56,6 +59,28 @@ static void setPreferredStatusBarStyle(UIWindow *window, UIStatusBarStyle style)
     [viewController setNeedsStatusBarAppearanceUpdate];
 }
 
+void togglePreferredStatusBarStyle()
+{
+    UIStatusBarStyle style = statusBarStyle(StatusBar::Light);
+    if(StatusBarPrivate::theme == StatusBar::Light) {
+        style = statusBarStyle(StatusBar::Dark);
+    }
+    UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+    if (keyWindow)
+        setPreferredStatusBarStyle(keyWindow, style);
+
+    QTimer* timer = new QTimer();
+    timer->setInterval(200);
+    timer->setSingleShot(true);
+    QObject::connect(timer, &QTimer::timeout, timer, []() {
+        UIStatusBarStyle style = statusBarStyle(StatusBarPrivate::theme);
+        UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+        if (keyWindow)
+            setPreferredStatusBarStyle(keyWindow, style);
+    }, Qt::UniqueConnection);
+    timer->start();
+}
+
 static void updatePreferredStatusBarStyle()
 {
     UIStatusBarStyle style = statusBarStyle(StatusBarPrivate::theme);
@@ -71,5 +96,11 @@ void StatusBarPrivate::setTheme_sys(StatusBar::Theme)
     QObject::connect(qApp, &QGuiApplication::applicationStateChanged, qApp, [](Qt::ApplicationState state) {
         if (state == Qt::ApplicationActive)
             updatePreferredStatusBarStyle();
+    }, Qt::UniqueConnection);
+
+    QScreen *screen = qApp->primaryScreen();
+    screen->setOrientationUpdateMask(Qt::PortraitOrientation | Qt::LandscapeOrientation | Qt::InvertedPortraitOrientation | Qt::InvertedLandscapeOrientation);
+    QObject::connect(screen, &QScreen::orientationChanged, qApp, [](Qt::ScreenOrientation) {
+        togglePreferredStatusBarStyle();
     }, Qt::UniqueConnection);
 }


### PR DESCRIPTION
Have tested with some devices and simulator and now the preferred style remains if orientation changes.
simply setting the style again doesn't help
setting the opposite theme and starting a QTimer to set to preferred style again works.